### PR TITLE
Add support for pyAE

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,11 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.2.7
+Date: 23 August 2022
+  Compatability:
+    - Added support for Py Alternative Energy
+  Bugfixes:
+    - Fixed restored missing locale key affecting fuse max consumption display
+---------------------------------------------------------------------------------------------------
 Version: 1.2.6
 Date: 12 August 2022
   Bugfixes:

--- a/info.json
+++ b/info.json
@@ -1,11 +1,11 @@
 {
     "name": "PowerOverload",
-    "version": "1.2.6",
+    "version": "1.2.7",
     "title": "Power Overload",
     "author": "Xorimuth",
     "description": "Performant, semi-realistic power distribution overhaul.\nPower poles can explode if the total electrical consumption on the network is too high. Use transformers to separate networks so that subnetworks do not take more power than they can handle.",
     "factorio_version": "1.1",
-    "dependencies": ["base >= 1.1.60", "? bzlead", "? aai-industry"],
+    "dependencies": ["base >= 1.1.60", "? bzlead", "? aai-industry", "? pyalternativeenergy"],
     "package": {
       "ignore": ["resources/*"]
     }

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -8,11 +8,13 @@ po-interface=High energy interface
 po-transformer=Transformer
 po-hidden-electric-pole-in=Transformer Input
 po-hidden-electric-pole-out=Transformer Output
+po-nexelit-power-fuse=Nexelit fuse
 
 [entity-description]
 po-electric-fuse=Much more likely to explode when overloaded and has a lower max consumption than the corresponding electric pole.
 po-transformer=Separates electric networks from each other
 po-interface=Can handle near-infinite amounts of power but can only supply one machine.\nCannot be rotated.
+po-electric-pole-consumption=[font=default-semibold][color=255, 230, 192]Max consumption:[/color][/font] __1__
 
 [mod-setting-name]
 power-overload-disconnect-different-poles=Automatically disconnect poles of different types

--- a/prototypes/fuse-recipes.lua
+++ b/prototypes/fuse-recipes.lua
@@ -1,6 +1,4 @@
-local pole_names = { "small-electric", "medium-electric", "big-electric", "huge-electric" }
-local name_prefix = "po-"
-local name_suffix = "-fuse"
+local shared = require "__PowerOverload__/shared"
 
 local function multiply_ingredients(from_recipe, to_recipe, name)
   to_recipe.result = name
@@ -28,13 +26,9 @@ local function multiply_ingredients(from_recipe, to_recipe, name)
   to_recipe.result_count = 1
 end
 
-for _, pole_name in pairs(pole_names) do
-  local name = name_prefix .. pole_name .. name_suffix
-
-  local prototype_name = pole_name .. "-pole"
-  if pole_name == "huge-electric" then  -- Already contains "po-" suffix
-    prototype_name = "po-huge-electric-pole"
-  end
+for _, pole_name in pairs(shared.get_poles_to_make_fuses(mods)) do
+  local name = shared.get_name_for_fuse(pole_name)
+  local prototype_name = shared.get_prototype_name_for_pole(pole_name)
 
   local base_recipe = data.raw.recipe[prototype_name]
   local recipe = table.deepcopy(base_recipe)

--- a/prototypes/fuses.lua
+++ b/prototypes/fuses.lua
@@ -1,16 +1,12 @@
+local shared = require "__PowerOverload__/shared"
+
 local red_tint = {r=1, g=0.6, b=0.6}
 
-local pole_names = { "small-electric", "medium-electric", "big-electric", "huge-electric" }
-local name_prefix = "po-"
-local name_suffix = "-fuse"
+for _, pole_name in pairs(shared.get_poles_to_make_fuses(mods)) do
+  local name = shared.get_name_for_fuse(pole_name)
+  local prototype_name = shared.get_prototype_name_for_pole(pole_name)
 
-for _, pole_name in pairs(pole_names) do
-  local name = name_prefix .. pole_name .. name_suffix
-  local prototype_name = pole_name .. "-pole"
-  if pole_name == "huge-electric" then  -- Already contains "po-" suffix
-    prototype_name = "po-huge-electric-pole"
-  end
-
+  log("Making fuse " .. name .. " from " .. prototype_name)
   local fuse = table.deepcopy(data.raw["electric-pole"][prototype_name])
   fuse.name = name
   fuse.minable.result = name

--- a/prototypes/pyalternativeenergy/technology.lua
+++ b/prototypes/pyalternativeenergy/technology.lua
@@ -1,0 +1,8 @@
+local electric_1_effects = data.raw.technology["electric-energy-distribution-1"].effects
+
+for _, recipe_name in pairs({"po-nexelit-power-fuse"}) do
+  table.insert(electric_1_effects, {
+    type = "unlock-recipe",
+    recipe = recipe_name
+  })
+end

--- a/prototypes/technology.lua
+++ b/prototypes/technology.lua
@@ -43,3 +43,7 @@ data:extend{
     order = "c-e-c"
   },
 }
+
+if mods["pyalternativeenergy"] then
+  require "pyalternativeenergy/technology"
+end

--- a/shared.lua
+++ b/shared.lua
@@ -92,6 +92,16 @@ local function get_pole_names(mods)
       ["substation-3"] = "240MW",
       ["substation-4"] = "260MW"
     },
+    ["pyalternativeenergy"] = {
+      ["small-electric-pole"] = "20MW",
+      ["medium-electric-pole"] = "200MW",
+      ["big-electric-pole"] = "2GW",
+      ["po-huge-electric-pole"] = "10GW",
+      ["substation"] = "400MW",
+      ["nexelit-power-pole"] = "800MW",
+      ["po-nexelit-power-fuse"] = "640MW",
+      ["nexelit-substation"] = "4GW"
+    }
   }
 
   local loaded_pole_names = {}
@@ -105,4 +115,44 @@ local function get_pole_names(mods)
   return loaded_pole_names
 end
 
-return {get_pole_names = get_pole_names, validate_and_parse_energy = validate_and_parse_energy}
+local function get_poles_to_make_fuses(mods)
+  -- Note, this assumes the naming convention always ends in '-pole'.  If this is not true, this and
+  -- other functions will need to be further modified.
+  local pole_names = { "small-electric", "medium-electric", "big-electric", "huge-electric" }
+
+  if mods["pyalternativeenergy"] then
+    table.insert(pole_names, "nexelit-power")
+  end
+
+  log(serpent.block(pole_names))
+  return pole_names
+end
+
+-- Returns the name of a fuse for a given pole name, defined in 'get_poles_to_make_fuses'
+local function get_name_for_fuse(pole_name)
+  local name_prefix = "po-"
+  local name_suffix = "-fuse"
+
+  local name = name_prefix .. pole_name .. name_suffix
+
+  return name
+end
+
+-- Returns the prototype of the pole used to make a fuse from a given pole name, defined in 'get_poles_to_make_fuses'
+local function get_prototype_name_for_pole(pole_name)
+
+  local prototype_name = pole_name .. "-pole"
+  if pole_name == "huge-electric" then  -- Huge electric pole is defined as 'po-huge-electric-pole', so we need a special case here.
+    prototype_name = "po-huge-electric-pole"
+  end
+
+  return prototype_name
+end
+
+return {
+  get_pole_names = get_pole_names,
+  validate_and_parse_energy = validate_and_parse_energy, 
+  get_poles_to_make_fuses = get_poles_to_make_fuses,
+  get_name_for_fuse = get_name_for_fuse,
+  get_prototype_name_for_pole = get_prototype_name_for_pole
+}


### PR DESCRIPTION
I added support for Py Alternative Energy (pyAE) which is currently in beta.  The only parts that are impacted are added in pyAE.
PyAE is here : https://drive.google.com/drive/folders/1t4pKJlHbfd5ELdSZKlH8gQkHrm6vZHAv
Py Discord is here :  https://discord.com/channels/560199483065892894/934240241110372412

To do this I did some minor refactoring to make it easier to add more mods in the future.  Take a look and see what you think.  The main thing I'm not thrilled with is the addition of a py-specific description for the fuse in locale.cfg.  I'm not very familiar with Factorio's localization features but if you know a way to add it programmatically, I'm happy to do so.

I also found an issue with fuse descriptions - po-electric-pole-consumption was removed, but still referenced by localized_description, so wasn't displaying properly.  I just restored po-electric-pole-consumption.

I've tested the following configurations and they work as expected, AFAIKT.  If there are edge cases you'd like me to validate, let me know and I can do so.
- Vanilla + only Power Overload
- K2+SE
- Full PyAE

It is safe to merge in now - pyAE is not released to the portal, and won't be until the update releases fully (Soon TM).  We can also defer the merge until it releases - up to you.

Thank you!