### PR TITLE
Py compatibility fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,13 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.4.4
+Date: 4 December 2022
+  Changes:
+    - PyAE 1.1.4 changed the location of the Nexlit power pole from electric-energy-distribution-1 to 3.  
+      This change updates the Nexelit fuse to the same location in the tech tree.
+    - Buffed slightly the wooden power pole and fuse to better match PyAE's early-game electricity usage (+37.5%).  This
+      setting will only be applied for new games - to apply it to an existing game, reset these values in mod settings to the new default.
+
+---------------------------------------------------------------------------------------------------
 Version: 1.4.3
 Date: 22 November 2022
   Features:

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@ Date: 4 December 2022
   Changes:
     - PyAE 1.1.4 changed the location of the Nexelit power pole from electric-energy-distribution-1 to 3.  
       This change updates the Nexelit fuse to the same location in the tech tree.
-    - Buffed slightly the wooden power pole and fuse to better match PyAE's early-game electricity usage (+37.5%).  This
+    - Buffed slightly the wooden power pole and fuse to better match PyAE's early-game electricity usage (+50%).  This
       setting will only be applied for new games - to apply it to an existing game, reset these values in mod settings to the new default.
 
 ---------------------------------------------------------------------------------------------------

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@
 Version: 1.4.4
 Date: 4 December 2022
   Changes:
-    - PyAE 1.1.4 changed the location of the Nexlit power pole from electric-energy-distribution-1 to 3.  
+    - PyAE 1.1.4 changed the location of the Nexelit power pole from electric-energy-distribution-1 to 3.  
       This change updates the Nexelit fuse to the same location in the tech tree.
     - Buffed slightly the wooden power pole and fuse to better match PyAE's early-game electricity usage (+37.5%).  This
       setting will only be applied for new games - to apply it to an existing game, reset these values in mod settings to the new default.

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "PowerOverload",
-    "version": "1.4.3",
+    "version": "1.4.4",
     "title": "Power Overload",
     "author": "Xorimuth",
     "homepage": "https://discord.gg/pkJc4v9nfT",
@@ -12,7 +12,7 @@
       "(?) bzaluminum",
       "(?) bzgas",
       "(?) aai-industry",
-      "(?) pyalternativeenergy",
+      "(?) pyalternativeenergy >= 1.1.4",
       "(?) IndustrialRevolution",
       "(?) PickerDollies"
     ],

--- a/prototypes/mod-compatibility.lua
+++ b/prototypes/mod-compatibility.lua
@@ -13,7 +13,7 @@ if mods["IndustrialRevolution"] then
 end
 
 if mods["pyalternativeenergy"] then
-  table.insert(data.raw.technology["electric-energy-distribution-1"].effects, {
+  table.insert(data.raw.technology["electric-energy-distribution-3"].effects, {
     type = "unlock-recipe",
     recipe = "po-nexelit-power-fuse"
   })

--- a/shared.lua
+++ b/shared.lua
@@ -126,11 +126,11 @@ local function get_pole_names(mods)
       ["big-wooden-pole"] = "150MW",
     },
     ["pycoalprocessing"] = {  -- Py 'base': covers all py combinations, overwrites base limits
-      ["small-electric-pole"] = "20MW",
+      ["small-electric-pole"] = "27.5MW",
       ["medium-electric-pole"] = "200MW",
       ["big-electric-pole"] = "2GW",
       ["po-huge-electric-pole"] = "10GW",
-      ["po-small-electric-fuse"] = "15MW",
+      ["po-small-electric-fuse"] = "22MW",
       ["po-medium-electric-fuse"] = "160MW",
       ["po-big-electric-fuse"] = "1.6GW",
       ["po-huge-electric-fuse"] = "8GW",

--- a/shared.lua
+++ b/shared.lua
@@ -126,11 +126,11 @@ local function get_pole_names(mods)
       ["big-wooden-pole"] = "150MW",
     },
     ["pycoalprocessing"] = {  -- Py 'base': covers all py combinations, overwrites base limits
-      ["small-electric-pole"] = "27.5MW",
+      ["small-electric-pole"] = "30MW",
       ["medium-electric-pole"] = "200MW",
       ["big-electric-pole"] = "2GW",
       ["po-huge-electric-pole"] = "10GW",
-      ["po-small-electric-fuse"] = "22MW",
+      ["po-small-electric-fuse"] = "25MW",
       ["po-medium-electric-fuse"] = "160MW",
       ["po-big-electric-fuse"] = "1.6GW",
       ["po-huge-electric-fuse"] = "8GW",


### PR DESCRIPTION
PyAE 1.1.4 changed the location of the Nexelit power pole and it's material dependencies.  This change updates the fuse to match the new location (electric-energy-distribution-3), which is much deeper in the tech tree.  Without this change, the fuse pushes electric-energy-distribution-1 way back in the tech tree.  This change restores it to it's correct spot.

I also took the opportunity to make a Py-specific balance change to the wooden power pole/fuse capacities.

I have tested with Pymods, K2+S2 and Vanilla.