### PR TITLE
Adding priority transformers

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -89,16 +89,16 @@ local function on_built(event)
       local blueprint_data = player and storage.blueprints_this_tick[event.player_index]
       on_pole_built(entity, false, player, blueprint_data)
 
-    elseif entity.name == "po-transformer" then
+    elseif entity.name == "po-transformer" or entity.name == "po-transformer-high" or entity.name == "po-transformer-low" then
       create_transformer(entity)
     end
   end
 end
 -- Needs to be 4 separate lines so that the filters work
-script.on_event(defines.events.on_built_entity, on_built, {{filter = "type", type = "electric-pole"}, {filter = "name", name = "po-transformer"}, {filter = "ghost_type", type = "electric-pole"}})
-script.on_event(defines.events.on_robot_built_entity, on_built, {{filter = "type", type = "electric-pole"}, {filter = "name", name = "po-transformer"}})
-script.on_event(defines.events.script_raised_revive, on_built, {{filter = "type", type = "electric-pole"}, {filter = "name", name = "po-transformer"}})
-script.on_event(defines.events.script_raised_built, on_built, {{filter = "type", type = "electric-pole"}, {filter = "name", name = "po-transformer"}})
+script.on_event(defines.events.on_built_entity, on_built, {{filter = "type", type = "electric-pole"}, {filter = "name", name = "po-transformer"}, {filter = "name", name = "po-transformer-high"}, {filter = "name", name = "po-transformer-low"}, {filter = "ghost_type", type = "electric-pole"}})
+script.on_event(defines.events.on_robot_built_entity, on_built, {{filter = "type", type = "electric-pole"}, {filter = "name", name = "po-transformer"}, {filter = "name", name = "po-transformer-high"}, {filter = "name", name = "po-transformer-low"}})
+script.on_event(defines.events.script_raised_revive, on_built, {{filter = "type", type = "electric-pole"}, {filter = "name", name = "po-transformer"}, {filter = "name", name = "po-transformer-high"}, {filter = "name", name = "po-transformer-low"}})
+script.on_event(defines.events.script_raised_built, on_built, {{filter = "type", type = "electric-pole"}, {filter = "name", name = "po-transformer"}, {filter = "name", name = "po-transformer-high"}, {filter = "name", name = "po-transformer-low"}})
 
 local function on_destroyed(event)
   local entity = event.entity
@@ -108,10 +108,10 @@ local function on_destroyed(event)
     entity.get_wire_connector(copper, false).disconnect_all()
   end
 end
-script.on_event(defines.events.on_pre_player_mined_item, on_destroyed, {{filter = "type", type = "electric-pole"}, {filter = "name", name = "po-transformer"}})
-script.on_event(defines.events.on_robot_pre_mined, on_destroyed, {{filter = "type", type = "electric-pole"}, {filter = "name", name = "po-transformer"}})
-script.on_event(defines.events.on_entity_died, on_destroyed, {{filter = "type", type = "electric-pole"}, {filter = "name", name = "po-transformer"}})
-script.on_event(defines.events.script_raised_destroy, on_destroyed, {{filter = "type", type = "electric-pole"}, {filter = "name", name = "po-transformer"}})
+script.on_event(defines.events.on_pre_player_mined_item, on_destroyed, {{filter = "type", type = "electric-pole"}, {filter = "name", name = "po-transformer"}, {filter = "name", name = "po-transformer-high"}, {filter = "name", name = "po-transformer-low"}})
+script.on_event(defines.events.on_robot_pre_mined, on_destroyed, {{filter = "type", type = "electric-pole"}, {filter = "name", name = "po-transformer"}, {filter = "name", name = "po-transformer-high"}, {filter = "name", name = "po-transformer-low"}})
+script.on_event(defines.events.on_entity_died, on_destroyed, {{filter = "type", type = "electric-pole"}, {filter = "name", name = "po-transformer"}, {filter = "name", name = "po-transformer-high"}, {filter = "name", name = "po-transformer-low"}})
+script.on_event(defines.events.script_raised_destroy, on_destroyed, {{filter = "type", type = "electric-pole"}, {filter = "name", name = "po-transformer"}, {filter = "name", name = "po-transformer-high"}, {filter = "name", name = "po-transformer-low"}})
 script.on_event(defines.events.on_object_destroyed,
   function(event)
     local unit_number = event.useful_id
@@ -190,7 +190,7 @@ script.on_event(defines.events.on_lua_shortcut,
 
 local function on_dolly_moved_entity(event)
   local transformer = event.moved_entity
-  if not transformer.name == "po-transformer" then return end
+  if not transformer.name == "po-transformer" and not transformer.name == "po-transformer-high" and not transformer.name == "po-transformer-low" then return end
   local transformer_parts = storage.transformers[transformer.unit_number]
   if not transformer_parts then return end
 
@@ -221,7 +221,8 @@ local function handle_picker_dollies()
     remote.call("PickerDollies", "add_blacklist_name", "po-hidden-electric-pole-alt")
     remote.call("PickerDollies", "add_blacklist_name", "po-transformer-interface-hidden-in")
     remote.call("PickerDollies", "add_blacklist_name", "po-transformer-interface-hidden-out")
-
+    remote.call("PickerDollies", "add_blacklist_name", "po-transformer-interface-hidden-out-high")
+    remote.call("PickerDollies", "add_blacklist_name", "po-transformer-interface-hidden-out-low")
   end
 
 end

--- a/control.lua
+++ b/control.lua
@@ -23,7 +23,7 @@ function is_fuse(pole)
 end
 
 ---@param player LuaPlayer?
----@return blueprint_entities BlueprintEntity[]?
+---@return BlueprintEntity[]?
 local function get_blueprint_entities(player)
   if not player or not player.is_cursor_blueprint() then return end
 
@@ -76,9 +76,12 @@ script.on_event(defines.events.on_pre_build, on_pre_build)
 local function on_built(event)
   local entity = event.entity
   if entity then
-    local player = event.name == defines.events.on_built_entity and game.get_player(event.player_index)
+    local player
+    if event.name == defines.events.on_built_entity then
+      player = game.get_player(event.player_index)
+    end
     if entity.type == "electric-pole" then
-      on_pole_built(entity, event.tags and event.tags["po-pole-ghost"], player)
+      on_pole_built(entity, event.tags and event.tags["po-pole-ghost"] == true, player)
     elseif entity.type == "entity-ghost" then
       local tags = entity.tags or {}
       tags["po-pole-ghost"] = true
@@ -282,7 +285,7 @@ end
 
 script.on_configuration_changed(
   function(changed_data)
-    script.blueprints_this_tick = storage.blueprints_this_tick or {}
+    storage.blueprints_this_tick = storage.blueprints_this_tick or {}
     update_global_settings()
 
     generate_max_consumption_table()

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "PowerOverload",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "title": "Power Overload",
     "author": "Xorimuth",
     "homepage": "https://discord.gg/pkJc4v9nfT",

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -6,13 +6,17 @@ po-huge-electric-fuse=Huge electric fuse
 po-huge-electric-pole=Huge electric pole
 po-interface=High energy interface
 po-transformer=Transformer
+po-transformer-high=Transformer (high priority)
+po-transformer-low=Transformer (low priority)
 po-hidden-electric-pole-in=Transformer Input
 po-hidden-electric-pole-out=Transformer Output
 po-nexelit-power-fuse=Nexelit fuse
 
 [entity-description]
 po-electric-fuse=Much more likely to explode when overloaded and has a lower maximum consumption than the corresponding electric pole.
-po-transformer=Separates electric networks from each other.\nEfficiency can be changed in mod settings.
+po-transformer=Separates electric networks from each other on medium priority.\nEfficiency can be changed in mod settings.
+po-transformer-high=Separates electric networks from each other on high priority.\nEfficiency can be changed in mod settings.
+po-transformer-low=Separates electric networks from each other on low priority.\nEfficiency can be changed in mod settings.
 po-interface=Can handle near-infinite amounts of power but only to one machine.\nCan be rotated once placed.
 
 [item-name]

--- a/prototypes/technology.lua
+++ b/prototypes/technology.lua
@@ -4,6 +4,14 @@ table.insert(electric_1_effects, {
   type = "unlock-recipe",
   recipe = "po-transformer"
 })
+table.insert(electric_1_effects, {
+  type = "unlock-recipe",
+  recipe = "po-transformer-high"
+})
+table.insert(electric_1_effects, {
+  type = "unlock-recipe",
+  recipe = "po-transformer-low"
+})
 
 data:extend{
   {

--- a/prototypes/transformer.lua
+++ b/prototypes/transformer.lua
@@ -66,6 +66,7 @@ local hidden_pole_in = {
   collision_mask = {layers={}},
   open_sound = big_pole.open_sound,
   close_sound = big_pole.close_sound,
+  auto_connect_up_to_n_wires = 0,  -- Only connections on-placement are by script, or as part of a blueprint
   connection_points =
   {
     {

--- a/prototypes/transformer.lua
+++ b/prototypes/transformer.lua
@@ -13,18 +13,40 @@ transformer.icons = {{
   icon = "__PowerOverload__/graphics/icons/transformer.png",
   icon_size = 64,
 }}
+local transformer_high = table.deepcopy(transformer)
+transformer_high.name = "po-transformer-high"
+transformer_high.minable.result = "po-transformer-high"
+transformer_high.placeable_by = {item = "po-transformer-high", count = 1}
+local transformer_low = table.deepcopy(transformer)
+transformer_low.name = "po-transformer-low"
+transformer_low.minable.result = "po-transformer-low"
+transformer_low.placeable_by = {item = "po-transformer-low", count = 1}
 
 
 local transformer_item = table.deepcopy(data.raw.item["power-switch"])
 transformer_item.name = "po-transformer"
 transformer_item.place_result = "po-transformer"
 transformer_item.subgroup = "energy-pipe-distribution"
-transformer_item.order = "a[energy]-f[transformer]"
+transformer_item.order = "a[energy]-f[transformer]-1"
 transformer_item.icons = table.deepcopy(transformer.icons)
+local transformer_item_high = table.deepcopy(transformer_item)
+transformer_item_high.name = "po-transformer-high"
+transformer_item_high.place_result = "po-transformer-high"
+transformer_item_high.order = "a[energy]-f[transformer]-2"
+local transformer_item_low = table.deepcopy(transformer_item)
+transformer_item_low.name = "po-transformer-low"
+transformer_item_low.place_result = "po-transformer-low"
+transformer_item_low.order = "a[energy]-f[transformer]-3"
 
 local transformer_recipe = table.deepcopy(data.raw.recipe["power-switch"])
 transformer_recipe.name = "po-transformer"
 transformer_recipe.results[1].name = "po-transformer"
+local transformer_high_recipe = table.deepcopy(data.raw.recipe["power-switch"])
+transformer_high_recipe.name = "po-transformer-high"
+transformer_high_recipe.results[1].name = "po-transformer-high"
+local transformer_low_recipe = table.deepcopy(data.raw.recipe["power-switch"])
+transformer_low_recipe.name = "po-transformer-low"
+transformer_low_recipe.results[1].name = "po-transformer-low"
 
 local hidden_pole_item = table.deepcopy(data.raw.item["small-electric-pole"])
 hidden_pole_item.name = "po-hidden-electric-pole"
@@ -135,6 +157,14 @@ hidden_eei_out.name = "po-transformer-interface-hidden-out"
 hidden_eei_out.energy_source.usage_priority = "secondary-output"
 hidden_eei_out.energy_source.input_flow_limit = "0J"
 hidden_eei_out.energy_source.output_flow_limit = "1YJ"
+local hidden_eei_out_high = table.deepcopy(hidden_eei_out)
+hidden_eei_out_high.name = "po-transformer-interface-hidden-out-high"
+hidden_eei_out_high.localised_name = {"entity-name.po-transformer-high"}
+hidden_eei_out_high.energy_source.usage_priority = "primary-output"
+local hidden_eei_out_low = table.deepcopy(hidden_eei_out)
+hidden_eei_out_low.name = "po-transformer-interface-hidden-out-low"
+hidden_eei_out_low.localised_name = {"entity-name.po-transformer-low"}
+hidden_eei_out_low.energy_source.usage_priority = "tertiary"
 
 -- Compatibility with dont-build-on-ores
 -- Probably doesn't actually work: https://mods.factorio.com/mod/PowerOverload/discussion/60757b90339b4cc3502cabea
@@ -147,4 +177,4 @@ for _, prototype in pairs({transformer, hidden_pole_in, hidden_pole_out}) do
 end
 
 
-data:extend{transformer, transformer_item, transformer_recipe, hidden_pole_item, hidden_pole_in, hidden_pole_out, hidden_pole_alt, hidden_eei_in, hidden_eei_out}
+data:extend{transformer, transformer_high, transformer_low, transformer_item, transformer_item_high, transformer_item_low, transformer_recipe, transformer_high_recipe, transformer_low_recipe, hidden_pole_item, hidden_pole_in, hidden_pole_out, hidden_pole_alt, hidden_eei_in, hidden_eei_out, hidden_eei_out_high, hidden_eei_out_low}

--- a/scripts/poles.lua
+++ b/scripts/poles.lua
@@ -31,13 +31,14 @@ local function modify_position(local_position, blueprint_data)
   }
 end
 
-local function is_entity_from_blueprint(entity, blueprint_data)
+local function is_ghost_from_blueprint(entity, blueprint_data)
   if not blueprint_data then return false end
+  if entity.type ~= "entity-ghost" then return false end
 
-  local entity_name = entity.name
+  local entity_name = entity.ghost_name
   local entity_position = entity.position
   for _, blueprint_entity in pairs(blueprint_data.blueprint_entities) do
-    if entity_name == blueprint_entity.name and entity_position = modify_position(blueprint_entity.position, blueprint_data) then
+    if entity_name == blueprint_entity.name and entity_position == modify_position(blueprint_entity.position, blueprint_data) then
       return true
     end
   end
@@ -48,7 +49,7 @@ end
 ---@param player LuaPlayer?
 ---@param blueprint_data table?
 function on_pole_built(pole, is_revive, player, blueprint_data)
-  local pole_name = pole.name
+  local pole_name = pole.type == "entity-ghost" and pole.ghost_name or pole.name
   if not is_revive then
     -- If entity was built as part of a revive, don't do any processing, since processing occured when the ghost was placed
     local pole_connector = pole.get_wire_connector(copper, true)
@@ -68,13 +69,13 @@ function on_pole_built(pole, is_revive, player, blueprint_data)
             disconnect_all --or always_disconnect[pole_name] or always_disconnect[neighbour_name]
             or (pole_name ~= neighbour_name and storage.global_settings["power-overload-disconnect-different-poles"])
           )
-          and not is_entity_from_blueprint(neighbour, blueprint_data)
+          and not is_ghost_from_blueprint(neighbour, blueprint_data)
           then
             pole_connector.disconnect_from(neighbour_connector)
       end
     end
   end
-  if storage.max_consumptions[pole_name] then
+  if storage.max_consumptions[pole_name] and pole.type ~= "entity-ghost" then
     if is_fuse(pole) then
       table.insert(storage.fuses, pole)
     else

--- a/scripts/transformer.lua
+++ b/scripts/transformer.lua
@@ -144,8 +144,13 @@ function check_transformer_interfaces(transformer_parts)
   end
 
   if not (transformer_parts.interface_out and transformer_parts.interface_out.valid) then
+    local transformer_to_interface = {
+      ["po-transformer"] = "po-transformer-interface-hidden-out",
+      ["po-transformer-high"] = "po-transformer-interface-hidden-out-high",
+      ["po-transformer-low"] = "po-transformer-interface-hidden-out-low"
+    }
     local interface_out = transformer_parts.transformer_surface.create_entity{
-      name = "po-transformer-interface-hidden-out",
+      name = transformer_to_interface[transformer_parts.transformer.name],
       position = transformer_parts.position_out,
       force = transformer_parts.force
     }

--- a/shared.lua
+++ b/shared.lua
@@ -40,7 +40,7 @@ local function get_pole_names(mods)
       ["po-big-electric-fuse"] = "240MW",
       ["po-huge-electric-fuse"] = "2.4GW",
       ["substation"] = "125MW",
-      ["po-substation-fuse"] = "100MW"
+      ["po-substation-fuse"] = "100MW",
       ["po-interface"] = "100GW",
       ["po-interface-north"] = "100GW",  -- Hidden from settings
       ["po-interface-east"] = "100GW",  -- Hidden from settings


### PR DESCRIPTION
This is a suggestion for adding priority transformers to the mod. It adds two more transformers to the mod, a high and a low priority transformer. IMHO they are kinda needed for the mod so that seperating accumulator or power generators to seperate networks otherwise doesn't work properly. It was also already suggested here: https://mods.factorio.com/mod/PowerOverload/discussion/63f60a606a787af6856d20e7 and deemed as good idea by Xorimuth.
I have tested it and it should work properly. I am not an artist though, so the 3 transformers have all the same texture. If you want I can try to color them, so that it might look better.
Another good idea might be to add in a shortcut to change the priority (and therefore the energy interface) on hover. I can look into this if you want, but didn't want to do the effort if the change isn't wanted in the first place.
