### PR TITLE
Add external electric pole registration API

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@
 - Angel's and 248k do not add any extra power poles, so should work. Nullius and 5Dim's are not supported
 - If you would like support for a particular mod, let me know. Since I haven't played many other mods, balance suggestions would be helpful
 
+## For modders
+Other mods can register electric poles for Power Overload to manage without needing direct compatibility changes here. Add an optional dependency on Power Overload, then register poles during `settings.lua` or `settings-updates.lua`:
+
+```lua
+if mods["PowerOverload"] then
+  require("__PowerOverload__/registry")
+
+  PowerOverload.register_pole{
+    name = "my-electric-pole",
+    default = "4GW"
+  }
+end
+```
+
+Power Overload will create a startup setting named `power-overload-max-power-my-electric-pole` and use that setting for tooltips and runtime overload handling if the prototype exists.
+
 ## Performance
 At the current level of optimisation, you should expect to be able to maintain 60UPS well into the hundreds of science-per-minute.
 As such, it works particularly well with smaller overhaul mods like Krastorio 2 and Industrial Revolution 2. Late-game Space Exploration or Pyanodons will likely run into UPS issues, although I do have future plans for further optimisation.

--- a/control.lua
+++ b/control.lua
@@ -193,6 +193,7 @@ script.on_event(defines.events.on_runtime_mod_setting_changed, update_global_set
 
 local function generate_max_consumption_table()
   local pole_names = shared.get_pole_names(script.active_mods)
+  pole_names = shared.get_pole_names_from_settings(pole_names, prototypes.entity, settings.startup)
   local max_consumptions = {}
   for pole_name, default_consumption in pairs(pole_names) do
     local setting_pole_name = shared.get_pole_aliases()[pole_name] or pole_name

--- a/prototypes/poles.lua
+++ b/prototypes/poles.lua
@@ -1,4 +1,5 @@
 local pole_names = shared.get_pole_names(mods)
+pole_names = shared.get_pole_names_from_settings(pole_names, data.raw["electric-pole"], settings.startup)
 for pole_name, prototype in pairs(data.raw["electric-pole"]) do
   pole_name = shared.get_pole_aliases()[pole_name] or pole_name
   local default_consumption = pole_names[pole_name]

--- a/registry.lua
+++ b/registry.lua
@@ -1,0 +1,35 @@
+PowerOverload = PowerOverload or {}
+
+local registered_poles = PowerOverload.registered_poles or {}
+PowerOverload.registered_poles = registered_poles
+
+function PowerOverload.register_pole(def)
+  if type(def) ~= "table" then
+    log("PowerOverload.register_pole expected a table")
+    return
+  end
+
+  if type(def.name) ~= "string" then
+    log("PowerOverload.register_pole expected def.name to be a string")
+    return
+  end
+
+  if type(def.default) ~= "string" then
+    log("PowerOverload.register_pole expected def.default to be a string for " .. def.name)
+    return
+  end
+
+  if registered_poles[def.name] then
+    log("PowerOverload pole registration for " .. def.name .. " overwritten")
+  end
+
+  registered_poles[def.name] = {
+    default = def.default,
+  }
+end
+
+function PowerOverload.get_registered_poles()
+  return registered_poles
+end
+
+return PowerOverload

--- a/settings-final-fixes.lua
+++ b/settings-final-fixes.lua
@@ -1,0 +1,27 @@
+util = require "__core__/lualib/util"
+local shared = require "shared"
+require "__PowerOverload__/registry"
+
+local pole_names = shared.get_pole_names(mods, PowerOverload.get_registered_poles())
+
+order = 0
+for pole_name, default_power in pairs(pole_names) do
+  if not shared.get_pole_aliases()[pole_name] then
+    if shared.validate_and_parse_energy(default_power) then
+      data:extend{
+        {
+          type = "string-setting",
+          name = "power-overload-max-power-" .. pole_name,
+          localised_name = {"", {"description.max-energy-consumption"}, ": [entity=" .. pole_name .. "] ", pole_name},
+
+          setting_type = "startup",
+          default_value = default_power,
+          order = string.format("%03d", tostring(order))
+        }
+      }
+      order = order + 1
+    else
+      log("Skipping Power Overload setting for " .. pole_name .. " with invalid default '" .. default_power .. "'")
+    end
+  end
+end

--- a/settings.lua
+++ b/settings.lua
@@ -1,5 +1,3 @@
-local shared = require "shared"
-
 data:extend{
   {
     type = "bool-setting",
@@ -33,21 +31,3 @@ data:extend{
     order = "d"
   },
 }
-
-order = 0
-for pole_name, default_power in pairs(shared.get_pole_names(mods)) do
-  if not shared.get_pole_aliases()[pole_name] then
-    data:extend{
-      {
-        type = "string-setting",
-        name = "power-overload-max-power-" .. pole_name,
-        localised_name = {"", {"description.max-energy-consumption"}, ": [entity=" .. pole_name .. "] ", pole_name},
-
-        setting_type = "startup",
-        default_value = default_power,
-        order = string.format("%03d", tostring(order))
-      }
-    }
-    order = order + 1
-  end
-end

--- a/shared.lua
+++ b/shared.lua
@@ -37,7 +37,7 @@ end
 
 -- These values are only the default values used in settings so changing them
 -- won't change the actual values: use mod settings for that
-local function get_pole_names(mods)
+local function get_pole_names(mods, registered_poles)
   local mod_pole_names = {
     ["base"] = {
       ["small-electric-pole"] = "10MW",  -- (10 MW is just over 20 steam engines-worth)
@@ -177,6 +177,9 @@ local function get_pole_names(mods)
     end
     combine_tables(loaded_pole_names, lighted_pole_names)
   end
+  for pole_name, def in pairs(registered_poles or {}) do
+    loaded_pole_names[pole_name] = def.default
+  end
   log(serpent.block(loaded_pole_names))
   return loaded_pole_names
 end
@@ -187,6 +190,28 @@ local function get_pole_aliases()
     ["po-interface-east"] = "po-interface",
     ["po-interface-south"] = "po-interface",
   }
+end
+
+local function is_electric_pole(electric_poles, pole_name)
+  local prototype = electric_poles[pole_name]
+  return prototype and prototype.type == "electric-pole"
+end
+
+local function get_pole_names_from_settings(pole_names, electric_poles, startup_settings)
+  local prefix = "power-overload-max-power-"
+
+  for setting_name, setting in pairs(startup_settings) do
+    if string.sub(setting_name, 1, string.len(prefix)) == prefix then
+      local pole_name = string.sub(setting_name, string.len(prefix) + 1)
+      if is_electric_pole(electric_poles, pole_name) then
+        pole_names[pole_name] = setting.value
+      elseif not get_pole_aliases()[pole_name] then
+        log("Power Overload setting found for unknown electric pole " .. pole_name)
+      end
+    end
+  end
+
+  return pole_names
 end
 
 local function get_poles_to_make_fuses(mods)
@@ -223,6 +248,7 @@ end
 
 return {
   get_pole_names = get_pole_names,
+  get_pole_names_from_settings = get_pole_names_from_settings,
   get_pole_aliases = get_pole_aliases,
   validate_and_parse_energy = validate_and_parse_energy,
   format_energy_number = format_energy_number,


### PR DESCRIPTION
## Summary

This adds a settings-stage registration API so other mods can opt their electric poles into Power Overload handling without requiring direct compatibility updates in Power Overload itself.

External mods can now do:

```lua
if mods["PowerOverload"] then
  require("__PowerOverload__/registry")

  PowerOverload.register_pole{
    name = "my-electric-pole",
    default = "4GW"
  }
end
```

## Changes

- Adds `PowerOverload.register_pole{name, default}` for settings-stage registration.
- Moves generated max-power startup settings to `settings-final-fixes.lua`.
- Discovers settings-backed electric poles in data/control so registered poles get tooltips and overload handling.
- Preserves existing built-in compatibility behavior.

## Rationale

Power Overload currently needs to know each supported electric pole prototype directly. That means external mods can add electric poles, but those poles are ignored by Power Overload unless this mod is updated with hardcoded compatibility data.

Providing a small registration API makes integration easier for other mod authors. They can declare their own poles and default overload values from their mod, while Power Overload remains responsible for creating the startup settings, tooltips, and runtime max-consumption table.

This also keeps the extension point in settings/data stage, where startup settings and prototype-related behavior can actually be configured.

## Validation

- Loaded locally with Power Overload symlinked into the Factorio mods folder.
- Confirmed registered poles can flow into generated startup settings and runtime overload handling.
- Ran Lua syntax checks with `luac -p`.
- Ran small Lua behavior checks around registration and settings-backed pole discovery.

## Note

Generative AI was used to support development of this change.
